### PR TITLE
Cache provider is not listed any more in the TTS configuration.

### DIFF
--- a/Editor/TextToSpeechConfigurationEditor.cs
+++ b/Editor/TextToSpeechConfigurationEditor.cs
@@ -20,17 +20,17 @@ namespace Innoactive.CreatorEditor.TextToSpeech.UI
         private void OnEnable()
         {
             textToSpeechConfiguration = (TextToSpeechConfiguration)target;
-            providers = ReflectionUtils.GetConcreteImplementationsOf<ITextToSpeechProvider>().ToList().Select(type => type.Name).ToArray();
-            lastProviderSelectedIndex = providersIndex = string.IsNullOrEmpty(textToSpeechConfiguration.Provider) ? Array.IndexOf(providers, typeof(MicrosoftSapiTextToSpeechProvider).Name) : Array.IndexOf(providers, textToSpeechConfiguration.Provider);
+            providers = ReflectionUtils.GetConcreteImplementationsOf<ITextToSpeechProvider>().ToList().Where(type => type != typeof(FileTextToSpeechProvider)).Select(type => type.Name).ToArray();
+            lastProviderSelectedIndex = providersIndex = string.IsNullOrEmpty(textToSpeechConfiguration.Provider) ? Array.IndexOf(providers, nameof(MicrosoftSapiTextToSpeechProvider)) : Array.IndexOf(providers, textToSpeechConfiguration.Provider);
             textToSpeechConfiguration.Provider = providers[providersIndex];
         }
 
         /// <inheritdoc />
         public override void OnInspectorGUI()
         {
-            providersIndex = EditorGUILayout.Popup("Provider", providersIndex, providers);
             DrawDefaultInspector();
-        
+            providersIndex = EditorGUILayout.Popup("Provider", providersIndex, providers);
+            
             if (providersIndex != lastProviderSelectedIndex)
             {
                 lastProviderSelectedIndex = providersIndex;

--- a/Runtime/TextToSpeechConfiguration.cs
+++ b/Runtime/TextToSpeechConfiguration.cs
@@ -64,7 +64,7 @@ namespace Innoactive.Creator.TextToSpeech
         /// <remarks>When used in runtime, this method can only retrieve config files located under a Resources folder.</remarks>
         public static TextToSpeechConfiguration LoadConfiguration()
         {
-            TextToSpeechConfiguration configuration = Resources.Load<TextToSpeechConfiguration>(typeof(TextToSpeechConfiguration).Name);
+            TextToSpeechConfiguration configuration = Resources.Load<TextToSpeechConfiguration>(nameof(TextToSpeechConfiguration));
             return configuration != null ? configuration : CreateNewConfiguration();
         }
         
@@ -75,7 +75,7 @@ namespace Innoactive.Creator.TextToSpeech
             
 #if UNITY_EDITOR
             string resourcesPath = "Assets/Resources/";
-            string configFilePath = $"{resourcesPath}{typeof(TextToSpeechConfiguration).Name}.asset";
+            string configFilePath = $"{resourcesPath}{nameof(TextToSpeechConfiguration)}.asset";
             
             if (Directory.Exists(resourcesPath) == false)
             {


### PR DESCRIPTION
### Description:

`FileTextToSpeechProvider` is not selectable anymore in the `TextToSpeechConfiguration` providers list.

![image](https://user-images.githubusercontent.com/6911992/80968818-e4f76800-8e18-11ea-8e5b-112319a8020a.png)

### Notes:

`FileTextToSpeechProvider` is used automatically if the `Save Audio Files To StreamingAssets` checkbox is set to true.
Manually selecting it causes misbehaviors.