### PR TITLE
Azure pipelines tag and version fix

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -81,7 +81,7 @@ stages:
               inputs:
                 targetType: 'inline'
                 script: |
-                  $TAG = (git tag --sort=committerdate | Select -last 1)
+                  $TAG = (git tag -l "v*" --sort=taggerdate | Select -last 1)
                   if(!$TAG) { $TAG = "v0.0.0" }
                   $TAG = $TAG.TrimStart("v") + "-" + (git log -1 --pretty=format:%h)
                   Write-Host "##vso[task.setvariable variable=Version]$TAG"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -81,7 +81,9 @@ stages:
               inputs:
                 targetType: 'inline'
                 script: |
-                  $TAG = (git describe --all --match "v*").Replace("tags/", "").TrimStart("v")
+                  $TAG = (git tag --sort=committerdate | Select -last 1)
+                  if(!$TAG) { $TAG = "v0.0.0" }
+                  $TAG = $TAG.TrimStart("v") + "-" + (git log -1 --pretty=format:%h)
                   Write-Host "##vso[task.setvariable variable=Version]$TAG"
                 workingDirectory: "TextToSpeech-Component/"
               
@@ -154,7 +156,7 @@ stages:
                 targetType: 'inline'
                 script: |
                   echo 'Exporting version $(Version)'
-                  ((Get-Content -path $(Path.ExportConfig)/$(ExportConfigName) -Raw) -replace '{version}','$(Version)') | Set-Content -Path $(Path.Project)/export-config.json
+                  ((Get-Content -path $(Path.ExportConfig)/$(ExportConfigName) -Raw) -replace '{version}','$v(Version)') | Set-Content -Path $(Path.Project)/export-config.json
                   u3d run -u $(UnityVersion) -- -projectPath '$(Path.Project)' -logFile $(Build.ArtifactStagingDirectory)/logs/editor_export.log -batchmode -quit -executeMethod Innoactive.CreatorEditor.PackageExporter.Export --export-config export-config.json
                   Start-Sleep -s 5
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -156,7 +156,7 @@ stages:
                 targetType: 'inline'
                 script: |
                   echo 'Exporting version $(Version)'
-                  ((Get-Content -path $(Path.ExportConfig)/$(ExportConfigName) -Raw) -replace '{version}','$v(Version)') | Set-Content -Path $(Path.Project)/export-config.json
+                  ((Get-Content -path $(Path.ExportConfig)/$(ExportConfigName) -Raw) -replace '{version}','v$(Version)') | Set-Content -Path $(Path.Project)/export-config.json
                   u3d run -u $(UnityVersion) -- -projectPath '$(Path.Project)' -logFile $(Build.ArtifactStagingDirectory)/logs/editor_export.log -batchmode -quit -executeMethod Innoactive.CreatorEditor.PackageExporter.Export --export-config export-config.json
                   Start-Sleep -s 5
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -81,7 +81,7 @@ stages:
               inputs:
                 targetType: 'inline'
                 script: |
-                  $TAG = (git tag -l "v*" --sort=taggerdate | Select -last 1)
+                  $TAG = (git tag -l "v*" --sort=committerdate | Select -last 1)
                   if(!$TAG) { $TAG = "v0.0.0" }
                   $TAG = $TAG.TrimStart("v") + "-" + (git log -1 --pretty=format:%h)
                   Write-Host "##vso[task.setvariable variable=Version]$TAG"


### PR DESCRIPTION
Description
- v prefix added to version.txt file
- version tag in non-build now grabs the latest tag and creates v0.0.0 if no tag exists