### PR TITLE
fix: voice value is not case sensitive anymore

### DIFF
--- a/Runtime/Provider/MicrosoftSapiTextToSpeechProvider.cs
+++ b/Runtime/Provider/MicrosoftSapiTextToSpeechProvider.cs
@@ -98,11 +98,13 @@ namespace Innoactive.Creator.TextToSpeech
             // If it is invalid, change it to neutral.
             string voice = configuration.Voice;
             
-            switch (voice)
+            switch (voice.ToLower())
             {
                 case "female":
+                    voice = "female";
                     break;
                 case "male":
+                    voice = "male";
                     break;
                 default:
                     voice = "neutral";


### PR DESCRIPTION
### Description
In MicrosoftSapiTextToSpeechProvider the voice value was case sensitive.
It caused some problems with our template.

**Fixes**: Using "Female" instead of "female".

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Using different values with different cases.

### Checklist

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules