### PR TITLE
refactor: make tts config more understandable and easier

### DIFF
--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -52,7 +52,7 @@ namespace Innoactive.Creator.TextToSpeech
             {
                 audioClip = await FallbackProvider.ConvertTextToSpeech(text);
 
-                if (Configuration.SaveAudioFilesToStreamingAssets)
+                if (Configuration.UseCache && (Configuration.StillWriteCacheWhenProjectIsBuilt || Application.isEditor))
                 {
                     CacheAudio(audioClip, filePath);
                 }

--- a/Runtime/TextToSpeechConfiguration.cs
+++ b/Runtime/TextToSpeechConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Innoactive.Creator.Core.Configuration;
 using UnityEngine;
@@ -25,22 +26,29 @@ namespace Innoactive.Creator.TextToSpeech
         public string Voice = "Male";
 
         /// <summary>
-        /// Usage of the standard HTML cache.
-        /// </summary>
-        public bool UseCache = true;
-
-        /// <summary>
         /// Enables the usage of the streaming asset folder as second cache directory to allow deliveries which work offline too.
         /// This means the StreamingAssets/{StreamingAssetCacheDirectoryName} will be searched first and only if there
         /// is no fitting audio file found the text to speech provider will be used to download the audio file from web.
         /// </summary>
+        public bool UseCache = true;
+
+        /// <inheritdoc cref="UseCache"/>
+        [Obsolete("Streaming Assets folder is now always used for caching. Use UseCache instead.")]
+        [HideInInspector]
         public bool UseStreamingAssetFolder = true;
 
         /// <summary>
-        /// With this option enabled the application tries to save the all downloaded audio files to
-        /// StreamingAssets/{StreamingAssetCacheDirectoryName}.
+        /// With this option enabled the application tries to save/cache all downloaded audio files to
+        /// StreamingAssets/{StreamingAssetCacheDirectoryName} during runtime when it is already built.
+        /// Should not be used when building for Android.
         /// </summary>
+        public bool StillWriteCacheWhenProjectIsBuilt = false;
+
+        /// <inheritdoc cref="StillWriteCacheWhenProjectIsBuilt"/>
+        [Obsolete("Use StillWriteCacheWhenProjectIsBuilt instead.")]
+        [HideInInspector]
         public bool SaveAudioFilesToStreamingAssets = false;
+
 
         /// <summary>
         /// StreamingAsset directory name which is used to load/save audio files.

--- a/Runtime/TextToSpeechProviderFactory.cs
+++ b/Runtime/TextToSpeechProviderFactory.cs
@@ -76,7 +76,7 @@ namespace Innoactive.Creator.TextToSpeech
 
             ITextToSpeechProvider provider = registeredProvider[configuration.Provider].Create(configuration);
             
-            if (configuration.UseStreamingAssetFolder)
+            if (configuration.UseCache)
             {
                 provider = new FileTextToSpeechProvider(provider, configuration);
             }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The TTS config now only has two instead of three booleans to manage caching.
It now always saves the cached audio files in StreamingAssets (there was no alternative before)
and the users can decide whether they want to also cache during runtime when the application
was already built or not.
This is useful when the TTS provider is not always available (e.g. no Internet connection).
Android cannot write into StreamingAssets, so this should be deactivated when building for Android.

**Fixes**: TTS config was not really understandable.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Refactor with obsoletes

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Tested on my machine. Also loaded older projects to check.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules