### PR TITLE
fix: google tts files are now properly reproduced from cache

### DIFF
--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -127,6 +127,8 @@ namespace Innoactive.Creator.TextToSpeech
             return FileManager.Exists(filePath);
         }
         
+        // Found at https://answers.unity.com/questions/737002/wav-byte-to-audioclip.html
+        // static int bytesToInt(byte[] bytes,int offset=0)
         private int CalculateRawFileFrequency(byte[] bytes, int offset=0)
         {
             int value=0;

--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -43,9 +43,10 @@ namespace Innoactive.Creator.TextToSpeech
             if (IsFileCached(filePath))
             {
                 byte[] bytes = GetCachedFile(filePath);
+                int bitrate = CalculateRawFileFrequency(bytes, 24);
                 float[] sound = TextToSpeechUtils.ShortsInByteArrayToFloats(bytes);
-                
-                audioClip = AudioClip.Create(text, channels: 1, frequency: 48000, lengthSamples: sound.Length, stream: false);
+
+                audioClip = AudioClip.Create(text, channels: 1, frequency: bitrate, lengthSamples: sound.Length, stream: false);
                 audioClip.SetData(sound, 0);
             }
             else
@@ -124,6 +125,18 @@ namespace Innoactive.Creator.TextToSpeech
         protected virtual bool IsFileCached(string filePath)
         {
             return FileManager.Exists(filePath);
+        }
+        
+        private int CalculateRawFileFrequency(byte[] bytes, int offset=0)
+        {
+            int value=0;
+            
+            for (int i=0; i<4; i++)
+            {
+                value |= bytes[offset+i] << (i*8);
+            }
+            
+            return value;
         }
         
         public class CouldNotLoadAudioFileException : Exception

--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -128,14 +128,13 @@ namespace Innoactive.Creator.TextToSpeech
         }
         
         // Found at https://answers.unity.com/questions/737002/wav-byte-to-audioclip.html
-        // static int bytesToInt(byte[] bytes,int offset=0)
         private int CalculateRawFileFrequency(byte[] bytes, int offset=0)
         {
-            int value=0;
+            int value = 0;
             
-            for (int i=0; i<4; i++)
+            for (int i = 0; i < 4; ++i)
             {
-                value |= bytes[offset+i] << (i*8);
+                value |= bytes[offset + i] << (i * 8);
             }
             
             return value;


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: The Mickey Mouse-like pitch when Google TTS files were used from cache.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Play a TTS behavior using google and cached files.