### PR TITLE
fix: sound issue is resolved by applying the offset to audio bytes

### DIFF
--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Innoactive.Creator.Core.IO;
 using UnityEngine;
-using UnityEngine.VFX;
 
 namespace Innoactive.Creator.TextToSpeech
 {

--- a/Runtime/Provider/FileTextToSpeechProvider.cs
+++ b/Runtime/Provider/FileTextToSpeechProvider.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Innoactive.Creator.Core.IO;
 using UnityEngine;
+using UnityEngine.VFX;
 
 namespace Innoactive.Creator.TextToSpeech
 {
@@ -44,7 +46,8 @@ namespace Innoactive.Creator.TextToSpeech
             {
                 byte[] bytes = GetCachedFile(filePath);
                 int bitrate = CalculateRawFileFrequency(bytes, 24);
-                float[] sound = TextToSpeechUtils.ShortsInByteArrayToFloats(bytes);
+                // Skipping the first offset * 2 bits to fix sound issues.
+                float[] sound = TextToSpeechUtils.ShortsInByteArrayToFloats(bytes.Skip(24 * 2).ToArray());
 
                 audioClip = AudioClip.Create(text, channels: 1, frequency: bitrate, lengthSamples: sound.Length, stream: false);
                 audioClip.SetData(sound, 0);


### PR DESCRIPTION
### Description
Adding 48 bytes of offset to the sound array removes the strange "clack" noise, only 24 bytes do not and more does not change. Seems like the magic number 🤷 

=> tested only with google